### PR TITLE
Change PHP example to use SSL endpoint in request

### DIFF
--- a/harvest_api_sample.php
+++ b/harvest_api_sample.php
@@ -1,9 +1,9 @@
 <?php
 
-        $credentials = "your_email_address:your_passwordpassword";
-        // just a sample below naturally you need to replace this with the right project and taks ids, as you cannot access these.
+        $credentials = "your_email_address:your_password";
+        // Replace the example data below with the project and task ids relevant to your account and request.
         $xml_data = "<request> <notes>qwer</notes> <hours>0.25</hours> <project_id>75406</project_id> <task_id>93182</task_id> <spent_at>Fri, 08 Feb 2008</spent_at> </request>";
-        $url = "http://YOURDOMAIN.harvestapp.com/daily/add";
+        $url = "https://YOURDOMAIN.harvestapp.com/daily/add";
 
         $headers = array(
             "Content-type: application/xml",
@@ -18,8 +18,6 @@
         curl_setopt($ch, CURLOPT_TIMEOUT, 60);
         curl_setopt($ch, CURLOPT_HTTPHEADER, $headers);
         curl_setopt($ch, CURLOPT_USERAGENT, "YOUR DESCRIPTIVE NAME GOES HERE");
-
-
         curl_setopt($ch, CURLOPT_POST, 1);
         curl_setopt($ch, CURLOPT_POSTFIELDS, $xml_data);
 


### PR DESCRIPTION
Support for non-SSL requests will be stopped in future, this change will let the example keep on working.
- Tightens comment about example data shown
- Fix typo on `your_password`
