### PR TITLE
Replace unmaintained Python library.

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A few of our users have implemented their own Harvest API wrappers. If you plan 
 * **Ruby**: [Harvested](http://github.com/zmoazeni/harvested), by Zach Moazeni
 * **Ruby**: [Harvest API Wrapper](http://github.com/aiaio/harvest/tree/master/lib), by Alexander Interactive
 * **PHP**: [HaPi - PHP Harvest API](http://labs.mdbitz.com/harvest-api/), by Matthew Denton
-* **Python**: [Harvest API Wrapper in Python](http://github.com/lann/Harvest), by Lann Martin and Brian Glass
+* **Python**: [Python Harvest API Client](https://github.com/lionheart/python-harvest), by Alex Goretoy
 * **Drupal**: [Harvest Module for Drupal](http://drupal.org/project/harvest), by ImageX Media
 * **Java**: [Harvest-client](http://github.com/moffermann/harvest-client), by Mauricio Offermann
 


### PR DESCRIPTION
Replace http://github.com/lann/Harvest with
https://github.com/lionheart/python-harvest as the former project's
README states that it is unmaintained and that lionheart library is a
good replacement.