### PR TITLE
Support for unicode chars in PowerShell output

### DIFF
--- a/v2/harvest_api_sample.ps1
+++ b/v2/harvest_api_sample.ps1
@@ -3,4 +3,5 @@ $Headers = @{}
 $Headers.Add("Authorization", "Bearer " + $Env:HARVEST_ACCESS_TOKEN)
 $Headers.Add("Harvest-Account-ID", $Env:HARVEST_ACCOUNT_ID)
 
-Invoke-WebRequest -Uri $Url -Headers $Headers | ConvertFrom-Json
+$content = [system.Text.Encoding]::UTF8.GetString((Invoke-WebRequest -Uri $Url -Headers $Headers).RawContentStream.ToArray())
+$content | ConvertFrom-Json 


### PR DESCRIPTION
Please see the support case "[Harvest Support] "Support for unicode chars in the API?"". The output does not support special chars when using Invoke-WebRequest. For some reason it uses the wrong encoding.

https://social.technet.microsoft.com/Forums/Lync/en-US/d795e7d2-dcf1-4323-8e06-8f06ce31a897/bug-invokerestmethod-and-utf8-data?forum=winserverpowershell

/Peter Selch Dahl