### PR TITLE
Remove references to outdated userscripts

### DIFF
--- a/v1/README.md
+++ b/v1/README.md
@@ -12,8 +12,3 @@ A few of our users have implemented their own Harvest API wrappers. If you plan 
 * **Python**: [Python Harvest API Client](https://github.com/lionheart/python-harvest), by Alex Goretoy
 * **Drupal**: [Harvest Module for Drupal](http://drupal.org/project/harvest), by ImageX Media
 * **Java**: [Harvest-client](http://github.com/moffermann/harvest-client), by Mauricio Offermann
-
-### Scripts
-
-* **Userscript**: [Toggle rounded time on timesheet](http://userscripts.org/scripts/show/95503), by Tim DeMoss
-* **Userscript**: [Toggle rounded time on detailed time report](http://userscripts.org/scripts/show/95575), by Tim DeMoss


### PR DESCRIPTION
The scripts listed on the ReadMe for the deprecated V1 API are no longer available.  This PR removes those from the readme.